### PR TITLE
Cleans up Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,27 +1,40 @@
 source 'https://rubygems.org'
+
 gem 'rails', '3.2.6'
 gem 'sqlite3'
+
+
+gem 'bootstrap-sass', '>= 2.0.3'
+gem 'cancan', '>= 1.6.8'
+gem 'devise', '>= 2.1.2'
+gem 'devise_invitable', '>= 1.0.2'
+gem 'google_visualr', '>= 2.1.2'
+gem 'haml', '>= 3.1.6'
+gem 'hominid'
+gem 'jquery-datatables-rails', '>= 1.10.0'
+gem 'jquery-rails'
+gem 'rolify', '>= 3.1.0'
+gem 'simple_form'
+
 group :assets do
   gem 'sass-rails',   '~> 3.2.3'
   gem 'coffee-rails', '~> 3.2.1'
   gem 'uglifier', '>= 1.0.3'
 end
-gem 'jquery-rails'
-gem "haml", ">= 3.1.6"
-gem "haml-rails", ">= 0.3.4", :group => :development
-gem "rspec-rails", ">= 2.10.1", :group => [:development, :test]
-gem "factory_girl_rails", ">= 3.5.0", :group => [:development, :test]
-gem "email_spec", ">= 1.2.1", :group => :test
-gem "cucumber-rails", ">= 1.3.0", :group => :test, :require => false
-gem "capybara", ">= 1.1.2", :group => :test
-gem "database_cleaner", ">= 0.8.0", :group => :test
-gem "launchy", ">= 2.1.0", :group => :test
-gem "hominid"
-gem "devise", ">= 2.1.2"
-gem "devise_invitable", ">= 1.0.2"
-gem "cancan", ">= 1.6.8"
-gem "rolify", ">= 3.1.0"
-gem "google_visualr", ">= 2.1.2"
-gem "jquery-datatables-rails", ">= 1.10.0"
-gem "bootstrap-sass", ">= 2.0.3"
-gem "simple_form"
+
+group :development do
+  gem 'haml-rails', '>= 0.3.4'
+end
+
+group :development, :test do
+  gem 'factory_girl_rails', '>= 3.5.0'
+  gem 'rspec-rails', '>= 2.10.1'
+end
+
+group :test do
+  gem 'capybara', '>= 1.1.2'
+  gem 'cucumber-rails', '>= 1.3.0', require: false
+  gem 'database_cleaner', '>= 0.8.0'
+  gem 'email_spec', '>= 1.2.1'
+  gem 'launchy', '>= 2.1.0'
+end


### PR DESCRIPTION
No gems were added, subtracted or changed. This pull is just to improve the eloquence.

This DRYs up the Gemfile by creating gem groups rather than assigning gems to groups inline. This should make the file much more organized. This also alphabetizes gems within their groups to make locating a specific gem much more efficient. The exception to this is is with rails and sqlite gems which were left at the top per convention (and so people can find which rails version and which data base the app uses at a glance.

I also made the quotes consistent. There were doubles and single quotes mixed together which caused visual clutter. I replaced the double quotes with single quotes to improve the consistency (and visual style) of the file.
