### PR TITLE
Fix broken specs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,10 @@ class User < ActiveRecord::Base
 
   # override Devise method
   # no password is required when the account is created; validate password when the user sets one
+  validates_confirmation_of :password
   def password_required?
     if !persisted? 
-      false
+      !(password != "")
     else
       !password.nil? || !password_confirmation.nil?
     end


### PR DESCRIPTION
This fix answers issue #17
https://github.com/RailsApps/rails-prelaunch-signup/issues/17

Here are the failing specs when I ran `rake spec` right after cloning to my local repo

```
~/rails-prelaunch-signup $ rake spec                                                                                            ruby-1.9.3-p194@rails-prelaunch-signup  [5s] 
/Users/pmc/.rvm/rubies/ruby-1.9.3-p194/bin/ruby -S rspec ./spec/controllers/home_controller_spec.rb ./spec/controllers/users_controller_spec.rb ./spec/mailers/user_mailer_spec.rb ./spec/models/user_spec.rb
..........FF.......




Failures:




  1) User password validations should require a password
     Failure/Error: User.new(@attr.merge(:password => "", :password_confirmation => "")).
       expected valid? to return false, got true
     # ./spec/models/user_spec.rb:70:in `block (3 levels) in <top (required)>'




  2) User password validations should require a matching password confirmation
     Failure/Error: User.new(@attr.merge(:password_confirmation => "invalid")).
       expected valid? to return false, got true
     # ./spec/models/user_spec.rb:75:in `block (3 levels) in <top (required)>'




Finished in 0.33531 seconds
19 examples, 2 failures




Failed examples:




rspec ./spec/models/user_spec.rb:69 # User password validations should require a password
rspec ./spec/models/user_spec.rb:74 # User password validations should require a matching password confirmation




Randomized with seed 37430




rake aborted!
/Users/pmc/.rvm/rubies/ruby-1.9.3-p194/bin/ruby -S rspec ./spec/controllers/home_controller_spec.rb ./spec/controllers/users_controller_spec.rb ./spec/mailers/user_mailer_spec.rb ./spec/models/user_spec.rb failed




Tasks: TOP => spec
(See full trace by running task with --trace)
```
