### PR TITLE
Hack to get around Rails 4 and Devise 3.0.0.rc issue

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -3,6 +3,7 @@ class RegistrationsController < Devise::RegistrationsController
   # override #create to respond to AJAX with a partial
   def create
     build_resource
+    resource.email = resource_params[:email]
 
     if resource.save
       if resource.active_for_authentication?


### PR DESCRIPTION
I dont know if you are looking for feedback on Rails 4, but upgrading to Devise 3.0.0.rc breaks the registration process.  It has to do with how Devise changed the build_resource method to support strong parameters.  This line no longer returns the visitors email address.  
https://github.com/RailsApps/rails-prelaunch-signup/blob/master/app/controllers/registrations_controller.rb#L5
The change in Devise here https://github.com/plataformatec/devise/blob/master/app/controllers/devise/registrations_controller.rb#L85 is the culprit.  
I made a hack to get around it and it may not be best way to fix it, but I thought I'd share it anyway. 
