### PR TITLE
Pull request to wait longer for Twitter & Google Plus

### DIFF
--- a/features/step_definitions/visitor_steps.rb
+++ b/features/step_definitions/visitor_steps.rb
@@ -31,7 +31,12 @@ Then /^I should see a form with a field "([^"]*)"$/ do |arg1|
 end
 
 Then /^I should see a message "([^\"]*)"$/ do |arg1|
+  save_wait_time = Capybara.default_wait_time
+# Make sure we wait enough for Twitter and Google Plus
+  Capybara.default_wait_time = 60 if 'Thank you!' == arg1
   page.should have_content (arg1)
+  Capybara.default_wait_time = save_wait_time
+
 end
 
 Then /^my email address should be stored in the database$/ do


### PR DESCRIPTION
This pull request lengthens a test timeout, and tightly targets the 'invitation thank you' modal window, to help ensure it loads completely (especially on constrained developer systems).

This not only increases the robustness of the current tests, but also gives elbow room to add more social app buttons in future.

This source change flows into gem rails_apps_composer [here](https://github.com/RailsApps/rails_apps_composer/blob/master/recipes/prelaunch.rb#L102).
