### PR TITLE
Devise 3.0 requires the "sign_up_params" parameter to be passed to the build_resource method in create method

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,7 +2,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   # override #create to respond to AJAX with a partial
   def create
-    build_resource
+    build_resource(sign_up_params)
 
     if resource.save
       if resource.active_for_authentication?


### PR DESCRIPTION
In create method, changed "build_resource" to "build_resource(sign_up_params)", otherwise, the resource is built without an email address. I'm using devise 3.0, it's registration controller does the same thing.
